### PR TITLE
add: sample for cpp11 string literals

### DIFF
--- a/cpp/cpp11
+++ b/cpp/cpp11
@@ -1,0 +1,7 @@
+
+// http://en.cppreference.com/w/cpp/language/string_literal
+const char* s1 = R"foo(
+not a newline: \n
+and " still valid here
+)foo";
+


### PR DESCRIPTION
Added code sample for new C++11 unescaped multiline string literals, see also:
http://en.cppreference.com/w/cpp/language/string_literal
